### PR TITLE
Trying the approach to just change forward diff gradient to threaded gradient

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationBase"
 uuid = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.0.1"
+version = "0.0.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/OptimizationSparseForwardDiff.jl
+++ b/ext/OptimizationSparseForwardDiff.jl
@@ -455,13 +455,15 @@ hess_colors = f.hess_colorvec
 if f.hess === nothing
     hess_sparsity = Symbolics.hessian_sparsity(_f, x)
     hess_colors = matrix_colors(tril(hess_sparsity))
-    hess = (res, θ, args...) -> numauto_color_hessian!(res, x -> _f(x, args...), θ,
-        ForwardColorHesCache(_f, x,
-            hess_colors,
-            hess_sparsity,
-            (res, θ) -> grad(res,
-                θ,
-                args...)))
+    # hess = (res, θ, args...) -> numauto_color_hessian!(res, x -> _f(x, args...), θ,
+    #     ForwardColorHesCache(_f, x,
+    #         hess_colors,
+    #         hess_sparsity,
+    #         (res, θ) -> grad(res,
+    #             θ,
+    #             args...)))
+    hess = (res, θ, args...) -> PolysterForwardDiff.threaded_jacobian!(grad(res, θ, args...), θ)
+                
 else
     hess = (H, θ, args...) -> f.hess(H, θ, p, args...)
 end

--- a/ext/OptimizationSparseForwardDiff.jl
+++ b/ext/OptimizationSparseForwardDiff.jl
@@ -419,7 +419,7 @@ function OptimizationBase.instantiate_function(f::OptimizationFunction{false},
     end
 
     if f.lag_h === nothing
-        lag_h = nothing # Consider implementing this
+        lag_h = nothing
     else
         lag_h = (θ, σ, μ) -> f.lag_h(θ, σ, μ, p)
     end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This is a draft PR for adding `PolyesterForwardDiff` for AD backed `Optimization`. So far, I have changed the gradient to threaded gradient. I still have to figure out how to implement the Hessian using PolyesterForwardDiff. I didn't because I am not sure If I should separately calculate the hessian and add it as `f.hess` or should I try adding some changes in the `numauto_color_hessian()`
 function.