### PR TITLE
optimize lagrangian implementation

### DIFF
--- a/src/OptimizationDISparseExt.jl
+++ b/src/OptimizationDISparseExt.jl
@@ -133,7 +133,11 @@ function instantiate_function(
         end
 
         function lagrangian(θ, σ, λ, p)
-            return σ * f.f(θ, p) + dot(λ, cons_oop(θ))
+            if iszero(θ)
+                return dot(λ, cons_oop(θ))
+            else
+                return σ * f.f(θ, p) + dot(λ, cons_oop(θ))
+            end
         end
     end
 


### PR DESCRIPTION
`σ = 0` is a common special case and it makes sense to optimize for it by not calling the cost function in this case